### PR TITLE
Add HOMELOAN to BankAccountType enum

### DIFF
--- a/source/OFXSharp/BankAccountType.cs
+++ b/source/OFXSharp/BankAccountType.cs
@@ -13,5 +13,7 @@ namespace OFXSharp
         [Description("Line of Credit")]
         CREDITLINE,
         NA,
+        [Description("Home Loan")]
+        HOMELOAN,
     }
 }

--- a/source/OFXSharp/OFXHelperMethods.cs
+++ b/source/OFXSharp/OFXHelperMethods.cs
@@ -12,7 +12,15 @@ namespace OFXSharp
       /// <returns>AccountInfo</returns>
       public static BankAccountType GetBankAccountType(this string bankAccountType)
       {
-         return (BankAccountType) Enum.Parse(typeof (BankAccountType), bankAccountType);
+          try
+          {
+              return (BankAccountType)Enum.Parse(typeof(BankAccountType), bankAccountType, true);
+          }
+          catch (Exception)
+          {
+
+              return BankAccountType.NA;
+          }  
       }
 
       /// <summary>


### PR DESCRIPTION
- add HOMELOAN to BankAccountType enum
- prevent exception if bank account type unknown 
- parse to enum ignore case

From OFX file for ABSA bank South Africa for home loan account.
`<ACCTTYPE>HomeLoan</ACCTTYPE>`