### PR TITLE
Support non delim header

### DIFF
--- a/source/OFXSharp/OFXDocumentParser.cs
+++ b/source/OFXSharp/OFXDocumentParser.cs
@@ -234,7 +234,7 @@ namespace OFXSharp
          CheckHeader(header);
 
          //Remove header
-         return file.Substring(file.IndexOf('<') - 1);
+         return file.Substring(file.IndexOf('<')).Trim();
       }
 
       /// <summary>

--- a/source/OFXSharp/OFXDocumentParser.cs
+++ b/source/OFXSharp/OFXDocumentParser.cs
@@ -243,6 +243,8 @@ namespace OFXSharp
       /// <param name="header">Header of OFX file in array</param>
       private void CheckHeader(string[] header)
       {
+		if (header[0] == "OFXHEADER:100DATA:OFXSGMLVERSION:102SECURITY:NONEENCODING:USASCIICHARSET:1252COMPRESSION:NONEOLDFILEUID:NONENEWFILEUID:NONE")//non delimited header
+			return;
          if (header[0] != "OFXHEADER:100")
             throw new OFXParseException("Incorrect header format");
 


### PR DESCRIPTION
Found one of the OFX suppliers was providing a non delimited header oddly.   I debated locally just replacing the malformed header with the correct one, but I figured as it does't harm library comparability I added it into the lib instead. 